### PR TITLE
Avoid send app.logs to github

### DIFF
--- a/account-microservice-migration/.gitignore
+++ b/account-microservice-migration/.gitignore
@@ -13,6 +13,17 @@ target/
 .springBeans
 .sts4-cache
 
+### .env Files ##
+.env
+.env.*
+
+### Logs ##
+app.log
+app-json-*.log
+
+### opentelemetry-javaagent.jar ###
+**/opentelemetry-javaagent.jar
+
 ### IntelliJ IDEA ###
 .idea
 *.iws

--- a/account-microservice/.gitignore
+++ b/account-microservice/.gitignore
@@ -19,7 +19,7 @@ target/
 
 ### Logs ##
 app.log
-
+app-json-*.log
 
 ### opentelemetry-javaagent.jar ###
 **/opentelemetry-javaagent.jar

--- a/statement-microservice/.gitignore
+++ b/statement-microservice/.gitignore
@@ -18,7 +18,8 @@ target/
 .env.*
 
 ### Logs ##
-logs/*
+app.log
+app-json-*.log
 
 ### opentelemetry-javaagent.jar ###
 **/opentelemetry-javaagent.jar

--- a/transaction-microservice/.gitignore
+++ b/transaction-microservice/.gitignore
@@ -17,6 +17,10 @@ target/
 .env
 .env.*
 
+### Logs ##
+app.log
+app-json-*.log
+
 ### opentelemetry-javaagent.jar ###
 **/opentelemetry-javaagent.jar
 


### PR DESCRIPTION
Configurado .gitignore dos módulos para evitar subir seus arquivos de logs para o github.